### PR TITLE
Add `reject_unauth_destination` to `smtpd_relay_restrictions`

### DIFF
--- a/roles/postfix/templates/main.cf.j2
+++ b/roles/postfix/templates/main.cf.j2
@@ -25,7 +25,7 @@ smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 # See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
 # information on enabling SSL in the smtp client.
 
-smtpd_relay_restrictions = permit_mynetworks
+smtpd_relay_restrictions = permit_mynetworks, reject_unauth_destination
 myhostname = {{ inventory_hostname }}
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases


### PR DESCRIPTION
Without this postfix does not start.

This closes #12