### PR TITLE
Separating files in os family specific

### DIFF
--- a/roles/logwatch/tasks/Debian.yml
+++ b/roles/logwatch/tasks/Debian.yml
@@ -1,0 +1,4 @@
+---
+
+- name: logwatch package installed
+  apt: pkg=logwatch state=present

--- a/roles/logwatch/tasks/RedHat.yml
+++ b/roles/logwatch/tasks/RedHat.yml
@@ -1,0 +1,4 @@
+---
+
+- name: logwatch package installed
+  yum: name=logwatch state=present

--- a/roles/logwatch/tasks/main.yml
+++ b/roles/logwatch/tasks/main.yml
@@ -1,12 +1,6 @@
 ---
 
-- name: logwatch package installed
-  when: ansible_os_family == 'Debian'
-  apt: pkg=logwatch state=present
-
-- name: logwatch package installed
-  when: ansible_os_family == 'RedHat'
-  yum: name=logwatch state=present
+- include: "{{ ansible_os_family }}.yml" 
 
 - name: Custom logwatch files present
   copy:

--- a/roles/munin-node/tasks/Debian.yml
+++ b/roles/munin-node/tasks/Debian.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Munin-Node package present
+  apt: pkg={{ item }} state=present
+  with_items:
+    - munin-node
+    - libwww-perl

--- a/roles/munin-node/tasks/RedHat.yml
+++ b/roles/munin-node/tasks/RedHat.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Munin-Node package present
+  when: ansible_os_family == 'RedHat'
+  yum: name={{ item }} state=present update_cache=yes
+  with_items:
+    - munin-node
+
+- name: Enable munin-node to start on boot - CentOS
+  service:
+    name=munin-node
+    enabled=yes

--- a/roles/munin-node/tasks/RedHat.yml
+++ b/roles/munin-node/tasks/RedHat.yml
@@ -1,7 +1,6 @@
 ---
 
 - name: Munin-Node package present
-  when: ansible_os_family == 'RedHat'
   yum: name={{ item }} state=present update_cache=yes
   with_items:
     - munin-node

--- a/roles/munin-node/tasks/main.yml
+++ b/roles/munin-node/tasks/main.yml
@@ -1,22 +1,6 @@
 ---
 
-- name: Munin-Node package present
-  when: ansible_os_family == 'Debian'
-  apt: pkg={{ item }} state=present
-  with_items:
-    - munin-node
-    - libwww-perl
-
-- name: Munin-Node package present
-  when: ansible_os_family == 'RedHat'
-  yum: name={{ item }} state=present update_cache=yes
-  with_items:
-    - munin-node
-
-- name: Enable munin-node to start on boot - CentOS
-  service:
-    name=munin-node
-    enabled=yes
+- include: "{{ ansible_os_family }}.yml"
 
 - name: Configure munin-node
   template:

--- a/roles/postfix/tasks/Debian.yml
+++ b/roles/postfix/tasks/Debian.yml
@@ -1,0 +1,4 @@
+---
+
+- name: Postfix present
+  apt: pkg=postfix state=present

--- a/roles/postfix/tasks/RedHat.yml
+++ b/roles/postfix/tasks/RedHat.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Postfix present
+  yum: name=postfix state=present
+
+- name: Enable Postfix to start on boot - CentOS
+  service:
+    name=postfix
+    enabled=yes

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -1,18 +1,6 @@
 ---
 
-- name: Postfix present
-  when: ansible_os_family == 'Debian'
-  apt: pkg=postfix state=present
-
-- name: Postfix present
-  when: ansible_os_family == 'RedHat'
-  yum: name=postfix state=present
-
-- name: Enable Postfix to start on boot - CentOS
-  service:
-    name=postfix
-    enabled=yes
-  when: ansible_os_family == 'RedHat'
+- include: "{{ ansible_os_family }}.yml"
 
 - name: Configure Postfix as forward-only server
   template:

--- a/roles/restart_script/tasks/Debian.yml
+++ b/roles/restart_script/tasks/Debian.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Ensure we have socat if we're load balancing
+  apt: pkg=socat state=present
+
+- name: Ensure we have curl
+  apt: pkg=curl state=present

--- a/roles/restart_script/tasks/RedHat.yml
+++ b/roles/restart_script/tasks/RedHat.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Ensure we have socat if we're load balancing
+  yum: name=socat state=present
+
+- name: Ensure we have curl
+  yum: name=curl state=present

--- a/roles/restart_script/tasks/main.yml
+++ b/roles/restart_script/tasks/main.yml
@@ -1,20 +1,6 @@
 ---
 
-- name: Ensure we have socat if we're load balancing
-  when: install_loadbalancer and ansible_os_family == 'Debian'
-  apt: pkg=socat state=present
-
-- name: Ensure we have socat if we're load balancing
-  when: install_loadbalancer and ansible_os_family == 'RedHat'
-  yum: name=socat state=present
-
-- name: Ensure we have curl
-  when: ansible_os_family == 'Debian'
-  apt: pkg=curl state=present
-
-- name: Ensure we have curl
-  when: ansible_os_family == 'RedHat'
-  yum: name=curl state=present
+- include: "{{ ansible_os_family }}.yml"
 
 - name: Create restart script
   template:


### PR DESCRIPTION
Split os-family-specific plays into separate include files in logwatch, munin-node, postfix and restart_script files.