### PR TITLE
Varnish fixes

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,5 +1,8 @@
 1.2.15 (unreleased)
 
+- The varnish default.vcl we generate had a logical error that would cause it to use the primary server incorrectly in some cases where multiple plones were installed and multiple hostnames in use. Fixed.
+  [smcmahon]
+
 - Allow myhostname in Postfix to be set to something other than the inventory hostname via a mail_hostname variable.
   [smcmahon]
 

--- a/roles/varnish/templates/default.vcl.j2
+++ b/roles/varnish/templates/default.vcl.j2
@@ -12,16 +12,16 @@ acl purge {
 sub vcl_recv {
 
 {% if playbook_plones|length > 1 %}
+    set req.backend_hint = {{ playbook_plones[0].plone_instance_name|default(plone_instance_name) }};
 {% for backend in playbook_plones %}
 {% for site in backend.webserver_virtualhosts|default([{'hostname':'default'}]) %}
-    if (req.url ~ "/{{ site.hostname }}:80/") {
-        set req.backend = {{ backend.plone_instance_name|default(plone_instance_name) }};
+{% if site.get('zodb_path') != None %}
+    if (req.url ~ "{{ site.protocol|default('http') }}/{{ site.hostname }}:") {
+        set req.backend_hint = {{ backend.plone_instance_name|default(plone_instance_name) }};
     }
+{% endif %}
 {% endfor %}
 {% endfor %}
-    else {
-        set req.backend = {{ playbook_plones[0].plone_instance_name|default(plone_instance_name) }};
-    }
 {% endif %}
 
     # Sanitize compression handling

--- a/roles/varnish/templates/default.vcl4.j2
+++ b/roles/varnish/templates/default.vcl4.j2
@@ -15,16 +15,16 @@ acl purge {
 sub vcl_recv {
 
 {% if playbook_plones|length > 1 %}
+    set req.backend_hint = {{ playbook_plones[0].plone_instance_name|default(plone_instance_name) }};
 {% for backend in playbook_plones %}
 {% for site in backend.webserver_virtualhosts|default([{'hostname':'default'}]) %}
-    if (req.url ~ "/{{ site.hostname }}:80/") {
+{% if site.get('zodb_path') != None %}
+    if (req.url ~ "{{ site.protocol|default('http') }}/{{ site.hostname }}:") {
         set req.backend_hint = {{ backend.plone_instance_name|default(plone_instance_name) }};
     }
+{% endif %}
 {% endfor %}
 {% endfor %}
-    else {
-        set req.backend_hint = {{ playbook_plones[0].plone_instance_name|default(plone_instance_name) }};
-    }
 {% endif %}
 
     call sanitize_compression;

--- a/sample-multiserver.yml
+++ b/sample-multiserver.yml
@@ -79,5 +79,5 @@ playbook_plones:
         zodb_path: /Plone
         extra: "# test comment here; added via extra"
         location_extra: "# test comment here; added via location_extra"
-
-
+      - hostname: test.example.com
+        zodb_path: /Plone

--- a/tests/multiserver.txt
+++ b/tests/multiserver.txt
@@ -39,6 +39,11 @@ Vagrant provision -- unless contraindicated.
     ...     print >> sys.stderr, "Provisioning"
     ...     run("vagrant provision %s" % box)
 
+Add a test host entry.
+
+    >>> command = "echo '127.0.0.1 test.example.com' | sudo tee -a /etc/hosts"
+    >>> p = subprocess.call('vagrant ssh %s -c "%s"' % (box, command), shell=True)
+
 Reboot the box. We only care about what survives a restart.
 
     >>> print >> sys.stderr, "Poweroff %s" % box
@@ -88,6 +93,7 @@ Check our motd.
     - xenial: *:80
     - xenial: *:443
     - localhost: *:80
+    - test.example.com:80
     <BLANKLINE>
 
 Use lsof to make sure we are listening on all expected ports
@@ -165,6 +171,7 @@ Is everything where we expect it to be?
     drwxr-xr-x  plone_buildout  plone_group bin
     -rw-r--r--  plone_buildout  plone_group bootstrap.py
     -rw-r--r--  plone_buildout  plone_group buildout.cfg
+    -rw-r--r--  plone_buildout  plone_group buildout.log
     drwxr-xr-x  plone_buildout  plone_group develop-eggs
     drwxr-xr-x  plone_buildout  plone_group include
     -rw-------  plone_buildout  plone_group .installed.cfg
@@ -294,6 +301,7 @@ Secondary instance tests
     drwxr-xr-x  plone_buildout  plone_group bin
     -rw-r--r--  plone_buildout  plone_group bootstrap.py
     -rw-r--r--  plone_buildout  plone_group buildout.cfg
+    -rw-r--r--  plone_buildout  plone_group buildout.log
     drwxr-xr-x  plone_buildout  plone_group develop-eggs
     -rw-------  plone_buildout  plone_group .installed.cfg
     drwxr-xr-x  plone_buildout  plone_group parts...
@@ -339,6 +347,12 @@ And, we should have gzip encoding available:
 Let's prove to ourselves that this is Plone 4:
 
     >>> output = ssh_run('curl --ipv4 http://localhost')
+    >>> output.find('barceloneta') >= 0
+    False
+
+Asking for test.example.com should also produce a Plone 4 page:
+
+    >>> output = ssh_run('curl --ipv4 http://test.example.com')
     >>> output.find('barceloneta') >= 0
     False
 


### PR DESCRIPTION
The varnish default.vcl we generate had a logical error that would cause it to use the primary server incorrectly in some cases where multiple plones were installed and multiple hostnames in use. Fixed.
