### PR TITLE
Add proxy_cache_vcl_extra

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,5 +1,8 @@
 1.2.17 (unreleased)
 
+- Add proxy_cache_vcl_extra variable that allows the addition of miscellaneous VCL to the varnish default.vcl file.
+  [smcmahon]
+
 - Add a new option plone_hot_monitor that may be set to `superlance` or `cron`.
   `superlance` is the default.
   If `cron` is specified, a cron script will run twice an hour to restart if memory use is hot.

--- a/docs/proxy_cache.rst
+++ b/docs/proxy_cache.rst
@@ -49,6 +49,7 @@ proxycache_method
 
 Use this to specify Varnish's cache mechanism. Default is ``malloc``.
 
+
 Cache controls
 ~~~~~~~~~~~~~~
 
@@ -69,4 +70,9 @@ These settings fine-tune the cache rules.
     # X-Anonymous header to allow split caching.
     nonanonymous_cookies: __ac(|_(name|password|persistent))
 
+    # Adds miscellaneous VCL; see the template files for location
+    proxy_cache_vcl_extra:
+
 Defaults are as indicated in the example. Don't change these without giving it some thought.
+
+

--- a/roles/varnish/defaults/main.yml
+++ b/roles/varnish/defaults/main.yml
@@ -18,3 +18,5 @@ cache_sanitize_cookie_exceptions: (statusmessages|__ac|_ZopeId|__cp|beaker\.sess
 # When these cookies are not found, mark request with
 # X-Anonymous header to allow split caching.
 nonanonymous_cookies: __ac(|_(name|password|persistent))
+
+proxy_cache_vcl_extra:

--- a/roles/varnish/templates/default.vcl.j2
+++ b/roles/varnish/templates/default.vcl.j2
@@ -24,6 +24,8 @@ sub vcl_recv {
 {% endfor %}
 {% endif %}
 
+{{ proxy_cache_vcl_extra }}
+
     # Sanitize compression handling
     if (req.http.Accept-Encoding) {
         if (req.url ~ "\.{{ nocompress_ext }}$") {

--- a/roles/varnish/templates/default.vcl4.j2
+++ b/roles/varnish/templates/default.vcl4.j2
@@ -27,6 +27,8 @@ sub vcl_recv {
 {% endfor %}
 {% endif %}
 
+{{ proxy_cache_vcl_extra }}
+
     call sanitize_compression;
 
     # Handle special requests


### PR DESCRIPTION
Add proxy_cache_vcl_extra variable that allows the addition of miscellaneous VCL to the varnish default.vcl file.