### PR TITLE
client_max_body_size global

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,5 +1,8 @@
 1.2.17 (unreleased)
 
+- Make client_max_body_size work either globally or in virtual host blocks.
+  [smcmahon]
+
 - Add proxy_cache_vcl_extra variable that allows the addition of miscellaneous VCL to the varnish default.vcl file.
   [smcmahon]
 

--- a/docs/webserver.rst
+++ b/docs/webserver.rst
@@ -48,11 +48,14 @@ Default value:
         zodb_path: /Plone
         aliases:
           - default
+        client_max_body_size: 2M
 
 .. note ::
 
     If you are setting up an https server, you must supply certificate and key files. The files will be copied from your local machine (the one containing the playbook) to the target server. Your key file must not be encrypted or you will not be able to start the web server automatically.
 
+    You may set ``client_max_body_size`` globally.
+    If you set it in virtual host blocks, it overrides the global setting.
 
 Certificates
 ~~~~~~~~~~~~

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -18,3 +18,5 @@ ssl_shared_conf: |
   {% if nginx_v_result.stdout | version_compare('1.5.9', 'ge') %}ssl_session_tickets off;{% endif %}
 
 allow_http2: yes
+
+client_max_body_size: 2M

--- a/roles/nginx/templates/host.j2
+++ b/roles/nginx/templates/host.j2
@@ -20,7 +20,7 @@ server {
 
   server_name {{ item.hostname }} {% for alias in item.get('aliases', []) %}{{ alias }} {% endfor %};
 
-  client_max_body_size {{ item.client_max_body_size|default('2M') }};
+  client_max_body_size {{ item.client_max_body_size|default(client_max_body_size) }};
 
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $remote_addr;


### PR DESCRIPTION
Make client_max_body_size work either globally or in virtual host blocks.