### PR TITLE
Add a default filter to the template, when plone_instance_name is not…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,6 @@
+1.2.11 (2017-06-02) unreleased
+------------------
+
+- Add default values for a template that use plone_instance_name. [ramiroluz]
+  roles/restart_script/templates/restart_if_hot.py.j2
+

--- a/roles/restart_script/templates/restart_if_hot.py.j2
+++ b/roles/restart_script/templates/restart_if_hot.py.j2
@@ -17,7 +17,7 @@ import subprocess
 
 # variables set by Ansible:
 admin_email = "{{ admin_email }}"
-instance_discriminator =  "{{ '%s_' % item.plone_instance_name }}"
+instance_discriminator =  "{{ '%s_' % item.plone_instance_name|default(plone_instance_name) }}"
 client_count = {{ item.plone_client_count|default(plone_client_count) }}
 max_memory = byte_size("{{ item.plone_client_max_memory|default(plone_client_max_memory) }}")
 restart_script = "{{ item.plone_target_path|default('/usr/local/plone-' + '.'.join(item.get('plone_version', plone_version).split('.')[0:2])) }}/{{ item.plone_instance_name|default(plone_instance_name) }}/scripts/restart_single_client.sh"


### PR DESCRIPTION
… defined. fix #94.