### PR TITLE
Fix fail2ban role for older versions of jail.conf.

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,5 +1,8 @@
 1.2.19 unreleased
 
+- The new fail2ban role (added in 1.2.15) would not work with older versions of jail.conf that set up an ssh jail rather than sshd.
+  [smcmahon]
+
 - Audit module would fail if no instance name was set.
   [smcmahon]
 

--- a/roles/fail2ban/tasks/main.yml
+++ b/roles/fail2ban/tasks/main.yml
@@ -2,6 +2,11 @@
 
 - include: "{{ ansible_os_family }}.yml"
 
+- name: Check fail2ban jail for [sshd]
+  command: 'grep -F "[sshd]" /etc/fail2ban/jail.conf'
+  ignore_errors: yes
+  register: sshd_check_result
+
 - name: "Local config in jail.d/customization.local"
   template:
     src: customization.local.j2

--- a/roles/fail2ban/templates/customization.local.j2
+++ b/roles/fail2ban/templates/customization.local.j2
@@ -10,7 +10,12 @@ maxretry: {{ fail2ban_maxretry }}
 banaction = iptables-multiport
 {% endif %}
 
+{% if sshd_check_result.rc == 0 %}
 [sshd]
 enabled = true
+{% else %}
+[ssh]
+enabled = true
+{% endif %}
 
 {{ fail2ban_extra }}

--- a/tests/medium.txt
+++ b/tests/medium.txt
@@ -184,6 +184,8 @@ Check fail2ban
     >>> print ssh_run('sudo fail2ban-client ping')
     Server replied: pong
 
+Note that this will return a false failure on older OS releases that use ``ssh`` rather than ``sshd``.
+
     >>> print ssh_run('sudo fail2ban-client status sshd')
      Status for the jail: sshd
     |- Filter


### PR DESCRIPTION
Older versions of jail.conf set up an "ssh" jail rather than "sshd". Make either work.