### PR TITLE
Replace ANXS.hostname with our own, simpler role.

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,3 +1,8 @@
+1.2.24 unreleased
+
+- Remove dependency on anxs.hostname.
+  [smcmahon]
+
 1.2.23 2018-02-20
 
 - Require plone_server 1.2.23.

--- a/playbook.yml
+++ b/playbook.yml
@@ -92,7 +92,7 @@
 
   roles:
 
-    - role: ANXS.hostname
+    - role: hostname
 
     - role: jnv.unattended-upgrades
       when: auto_upgrades|default(True) and ansible_os_family == 'Debian'

--- a/requirements.yml
+++ b/requirements.yml
@@ -7,7 +7,3 @@
 - src: https://github.com/jnv/ansible-role-unattended-upgrades.git
   version: v1.3.0
   name: jnv.unattended-upgrades
-
-- src: https://github.com/ANXS/hostname.git
-  version: v1.1.0
-  name: ANXS.hostname

--- a/roles/hostname/LICENSE
+++ b/roles/hostname/LICENSE
@@ -1,0 +1,24 @@
+The "hostname" role in the Plone Ansible Playbook is largely derived from ANXS.hostname, which carries the MIT license. That license and copyright notice are reproduced below.
+
+
+The MIT License
+
+Copyright (c) 2014 Pieterjan Vandaele
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/roles/hostname/tasks/main.yml
+++ b/roles/hostname/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+
+- name: Hostname | Update the hostname (pt. 1) - hostname cmd
+  hostname:
+    name: "{{inventory_hostname_short}}"
+
+- name: Hostname | Update the hostname (pt. 2) - (/etc/hostname)
+  copy:
+    content: "{{inventory_hostname_short}}{{'\n'}}"
+    dest: /etc/hostname
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Hostname | Update the IPv4 hostname (pt. 3) - (/etc/hosts)
+  lineinfile:
+    dest: /etc/hosts
+    regexp: "^127.0.0.1"
+    line: "127.0.0.1{{'\t'}}{{inventory_hostname}}{% if inventory_hostname != inventory_hostname_short %}{{'\t'}}{{inventory_hostname_short}}{% endif %}{{'\t'}}localhost"
+    state: present
+
+- name: Hostname | Update the IPv6 hostname (pt. 3) - (/etc/hosts)
+  lineinfile:
+    dest: /etc/hosts
+    regexp: "^::1"
+    line: "::1{{'\t\t'}}{{inventory_hostname}}{% if inventory_hostname != inventory_hostname_short %}{{'\t'}}{{inventory_hostname_short}}{% endif %}{{'\t'}}localhost ip6-localhost ip6-loopback"
+    state: present

--- a/tests/medium.txt
+++ b/tests/medium.txt
@@ -53,6 +53,12 @@ And, now run tests against the box.
 
     >>> print >> sys.stderr, "Running tests against box"
 
+Check hostname:
+
+    >>> rez = ssh_run('hostname')
+    >>> rez.strip() == box
+    True
+
 Use lsof to make sure we are listening on all expected ports
 in all expected ways.
 


### PR DESCRIPTION
ANXS.hostname is great, but does more than we need. Simplify and use as our own built-in hostname role.