### PR TITLE
Fix fail2ban install on hosts with no jail.d

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,5 +1,8 @@
 1.2.24 unreleased
 
+- fail2ban install was failing on hosts with no /etc/fail2ban/jail.d directory (after the fail2ban package install). Fixed.
+  [smcmahon]
+
 - Remove dependency on anxs.hostname.
   [smcmahon]
 

--- a/roles/fail2ban/tasks/main.yml
+++ b/roles/fail2ban/tasks/main.yml
@@ -7,6 +7,12 @@
   ignore_errors: yes
   register: sshd_check_result
 
+- name: Ensure jail.d directory
+  file:
+    path=/etc/fail2ban/jail.d
+    state=directory
+    mode=0755
+
 - name: "Local config in jail.d/customization.local"
   template:
     src: customization.local.j2

--- a/tests/medium.txt
+++ b/tests/medium.txt
@@ -191,15 +191,7 @@ Check fail2ban
     >>> print ssh_run('sudo fail2ban-client ping')
     Server replied: pong
 
-Note that this will return a false failure on older OS releases that use ``ssh`` rather than ``sshd``.
-
-    >>> print ssh_run('sudo fail2ban-client status sshd')
-     Status for the jail: sshd
-    |- Filter
-    |  |- Currently failed: 0
-    |  |- Total failed: 0
-    |  `- ...
-    `- Actions
-       |- Currently banned: 0
-       |- Total banned: 0
-       `- Banned IP list:
+    >>> print ssh_run('sudo fail2ban-client status')
+    Status
+    |- Number of jail:  1
+    `- Jail list:       ssh...


### PR DESCRIPTION
Some older environments (wheezy) lack /etc/fail2ban/jail.d directories after the fail2ban package install. This caused our fail2ban install to fail. Fixed by making sure that directory exists.