### PR TITLE
Fix version compare

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,3 +1,8 @@
+Unreleased
+
+- Fix version compare and align with ansible.plone_server.
+  [stevepiercy]
+
 1.3.7 2019-07-24
 
 - Set up the multiserver sample with 4.3, 5.1 and 5.2 for a thorough example and test.

--- a/playbook.yml
+++ b/playbook.yml
@@ -10,7 +10,7 @@
 
     - name: Fail if Ansible is old
       fail: msg="We need updates in Ansible 2.5.0. Please update your kit. 'pip install -U Ansible'"
-      when: ansible_version is version('2.5.0', 'lt')
+      when: ansible_version.full is version('2.5.0', '<')
       tags:
         - always
 


### PR DESCRIPTION
This PR fixes the following error message.

```
TASK [Fail if Ansible is old] *****************************************************************************************************************************************************************************************************************************************
fatal: [example.com]: FAILED! => {"msg": "The conditional check 'ansible_version is version('2.5.0', 'lt')' failed. The error was: Version comparison: '<' not supported between instances of 'str' and 'int'\n\nThe error appears to be in '/project-path/plone/ansible-playbook/playbook.yml': line 11, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Fail if Ansible is old\n      ^ here\n"}
```

Its complement was merged in https://github.com/plone/ansible.plone_server/pull/134