### PR TITLE
Certbot support using certbot nginx plugin

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,3 +1,9 @@
+1.3.9 unreleased
+
+- Add certbot playbook, role and documentation.
+  Provides LetsEncrypt support using certbot-nginx plugin.
+  [smcmahon, stevepiercy]
+
 1.3.8 2020-02-15
 
 - Test against 5.2.1.

--- a/docs/certbot.rst
+++ b/docs/certbot.rst
@@ -1,0 +1,52 @@
+Certbot options
+```````````````
+
+The certbot playbook
+~~~~~~~~~~~~~~~~~~~~
+
+As a convenience, the Plone Ansible Playbook kit includes a separate
+playbook that will install certbot-nginx and create certificates as necessary for specified hostnames.
+
+The certbot playbook currently only supports Debian-family target servers.
+
+To use the certbot playbook, edit your ``local-configure.yml`` file to add a ``certbot_hosts`` list variable containing an entry for each hostname for which you wish to get a certbot certificate:
+
+.. code-block:: yaml
+
+   certbot_hosts:
+     - one.mcsmith.org
+     - two.mcsmith.org
+
+Run the playbook as you would the main playbook, adding whatever command-line switches you need (like ``-k`` or ``-K``):
+
+.. code-block:: console
+
+    ansible-playbook -k certbot.yml
+
+This will first install ``python3-certbot-nginx`` from the certbot/certbot ppa.
+Then it will create certificates as necessary for each hostname in the ``certbot_hosts`` list.
+If a certificate already exists, it will not attempt addition.
+
+Note that ``python3-certbot-nginx`` includes an auto-renewal cronjob.
+
+
+Webserver support
+~~~~~~~~~~~~~~~~~
+
+When the nginx role creates a configuration file for an virtual host, it will check ssl hostnames against the ``certbot_hosts`` list.
+If the hostname matches, the certbot certificate/key will be used automatically (unless you override this by specifying certificate/key files).
+
+Certificate/key files for certbot are expected to be in ``/etc/letsencrypt/live/HOST_NAME`` or this mechanism will fail when nginx is reloaded after configuration.
+
+
+Why is this a separate playbook?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As with the ``firewall.yml`` playbook, we want to encourage users to think and research before using the certbot playbook.
+*Let's Encrypt* is security software and is not for everyone.
+It should be used only with knowledge and deliberation and not as an autopilot choice.
+
+Note in particular that the certbot-nginx support uses root priveleges for both certificate creation and renewal.
+Some sysadmins choosing certbot may wish to set up their own creation/renewal systems to avoid this exposure.
+
+Note that even if you never run the certbot playbook, you may still find the webserver setup support useful.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,4 +24,4 @@ Plone's Ansible Playbook
    multiserver
    restart_script
    audit
-   cetbot
+   certbot

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,3 +24,4 @@ Plone's Ansible Playbook
    multiserver
    restart_script
    audit
+   cetbot

--- a/docs/webserver.rst
+++ b/docs/webserver.rst
@@ -89,6 +89,17 @@ To use files that already exist on the controlled server, use:
           key: /etc/ssl/private/ssl-cert-snakeoil.key
           crt: /etc/ssl/certs/ssl-cert-snakeoil.pem
 
+.. code-block:: yaml
+
+An shortcut if you're using certbot for certificates and the certificates are in the usual ``/etc/letsencrypt/live/HOST_NAME`` folders.
+If you specify a global ``certbot_hosts`` list variable, then these certificates will be used for all matching hosts.
+
+   certbot_hosts:
+     - one.mcsmith.org
+     - two.mcsmith.org
+
+Remember, the ``certbot_hosts`` variable must be global, not part of ``webserver_virtualhosts`` list.
+
 
 Redirections, etc.
 ~~~~~~~~~~~~~~~~~~

--- a/docs/webserver.rst
+++ b/docs/webserver.rst
@@ -89,16 +89,26 @@ To use files that already exist on the controlled server, use:
           key: /etc/ssl/private/ssl-cert-snakeoil.key
           crt: /etc/ssl/certs/ssl-cert-snakeoil.pem
 
-.. code-block:: yaml
+Alternatively, you can use certbot to create and renew certificates.
+Certificates are in the usual ``/etc/letsencrypt/live/HOST_NAME`` folders.
+If you specify a global ``certbot_hosts`` list variable, then certificates managed by certbot from Let's Encrypt will be used for all matching hosts.
 
-An shortcut if you're using certbot for certificates and the certificates are in the usual ``/etc/letsencrypt/live/HOST_NAME`` folders.
-If you specify a global ``certbot_hosts`` list variable, then these certificates will be used for all matching hosts.
+.. code-block:: yaml
 
    certbot_hosts:
      - one.mcsmith.org
      - two.mcsmith.org
 
+Or if you have the ``inventory_hostname`` variable defined:
+
+.. code-block:: yaml
+
+   certbot_hosts:
+     - "{{ inventory_hostname }}"
+
 Remember, the ``certbot_hosts`` variable must be global, not part of ``webserver_virtualhosts`` list.
+Also the ``certificate`` key and items under ``webserver_virtualhosts`` takes precedence over all other certificate management methods.
+If you want to use certbot, then remove the ``certificate`` block.
 
 
 Redirections, etc.

--- a/docs/webserver.rst
+++ b/docs/webserver.rst
@@ -106,6 +106,14 @@ Or if you have the ``inventory_hostname`` variable defined:
    certbot_hosts:
      - "{{ inventory_hostname }}"
 
+To automatically renew the certificates, you need to set the time you want to attempt renewal on a daily basis with the ``certbot_renew_at`` global variable.
+
+.. code-block:: yaml
+
+    certbot_renew_at:
+      minute: 30
+      hour: 3
+
 Remember, the ``certbot_hosts`` variable must be global, not part of ``webserver_virtualhosts`` list.
 Also the ``certificate`` key and items under ``webserver_virtualhosts`` takes precedence over all other certificate management methods.
 If you want to use certbot, then remove the ``certificate`` block.

--- a/roles/certbot/tasks/Debian.yml
+++ b/roles/certbot/tasks/Debian.yml
@@ -12,4 +12,4 @@
 - name: Install python3-certbot-nginx
   package:
     name: "python3-certbot-nginx"
-    state: present
+    state: latest

--- a/roles/certbot/tasks/main.yml
+++ b/roles/certbot/tasks/main.yml
@@ -16,3 +16,8 @@
   args:
     creates: "/etc/letsencrypt/live/{{ item }}/cert.pem"
   loop: "{{ certbot_hosts }}"
+
+- name: "Test renewal with a dry run."
+  shell: >
+    certbot renew --dry-run
+    

--- a/roles/certbot/tasks/main.yml
+++ b/roles/certbot/tasks/main.yml
@@ -20,13 +20,3 @@
 - name: "Test renewal with a dry run."
   shell: >
     certbot renew --dry-run --nginx
-
-- name: Cron job to auto renew certificates via certbot
-  when: certbot_renew_at|bool
-  cron:
-    name="Automatically renew Let's Encrypt certificates via certbot"
-    job="certbot renew --quiet --no-self-upgrade --nginx"
-    user=root
-    minute={{ item.minute }}
-    hour={{ item.hour }}
-  with_items: "{{ [certbot_renew_at] }}"

--- a/roles/certbot/tasks/main.yml
+++ b/roles/certbot/tasks/main.yml
@@ -19,5 +19,4 @@
 
 - name: "Test renewal with a dry run."
   shell: >
-    certbot renew --dry-run
-    
+    certbot renew --dry-run --nginx

--- a/roles/certbot/tasks/main.yml
+++ b/roles/certbot/tasks/main.yml
@@ -20,3 +20,13 @@
 - name: "Test renewal with a dry run."
   shell: >
     certbot renew --dry-run --nginx
+
+- name: Cron job to auto renew certificates via certbot
+  when: certbot_renew_at|bool
+  cron:
+    name="Automatically renew Let's Encrypt certificates via certbot"
+    job="certbot renew --quiet --no-self-upgrade --nginx"
+    user=root
+    minute={{ item.minute }}
+    hour={{ item.hour }}
+  with_items: "{{ [certbot_renew_at] }}"

--- a/roles/nginx/templates/host.j2
+++ b/roles/nginx/templates/host.j2
@@ -5,6 +5,9 @@ server {
 {% if item.get('certificate') %}
   ssl_certificate {{ item.certificate.crt }};
   ssl_certificate_key {{ item.certificate.key }};
+{% elif certbot_hosts is defined and item.hostname in certbot_hosts %}
+  ssl_certificate /etc/letsencrypt/live/{{ item.hostname }}/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/{{ item.hostname }}/privkey.pem;
 {% else %}
   ssl_certificate /etc/nginx/ssl/{{ item.hostname }}.crt;
   ssl_certificate_key /etc/nginx/ssl/{{ item.hostname }}.key;


### PR DESCRIPTION
Simplifies using playbook to issue and use LetsEncrypt certificates.