### PR TITLE
Correct ansible-galaxy command in docs

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,5 +1,9 @@
 1.3.9 unreleased
 
+
+- Correct ansible-galaxy command in docs
+  [djowett]
+
 - Add "tcp-check connect" to haproxy tcp-check sequence.
   Fixes #123.
   Thanks, jid.

--- a/docs/custom_playbook.rst
+++ b/docs/custom_playbook.rst
@@ -21,7 +21,7 @@ Picking up required roles
 
 *Roles* are packages of Ansible settings and tasks. The Plone Playbook has separate roles for each of the major components it works with. These roles are not included with the playbook itself, but they are easy to install.
 
-To install the required roles, issue the command ``ansible-galaxy -p roles -r requirements.yml install`` from the playbook directory. This will create a roles subdirectory and fill it with the required roles.
+To install the required roles, issue the command ``ansible-galaxy install -p roles -r requirements.yml`` from the playbook directory. This will create a roles subdirectory and fill it with the required roles.
 
 If you want to store your roles elsewhere, edit the ``ansible.cfg`` file in the playbook directory.
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -40,7 +40,7 @@ TL;DR
 
 3. Check out or download a copy of `the STABLE branch of this package <https://github.com/plone/ansible-playbook>`_;
 
-4. Run ``ansible-galaxy -p roles -r requirements.yml install`` to install required roles;
+4. Run ``ansible-galaxy install -p roles -r requirements.yml`` to install required roles;
 
 5. Copy one of the ``sample*.yml`` files to ``local-configure.yml`` and edit as needed.
 


### PR DESCRIPTION
`ansible-galaxy install -p roles -r requirements.yml` works whereas this doesn't

```
$ ansible-galaxy -p roles -r requirements.yml install
usage: ansible-galaxy role [-h] ROLE_ACTION ...
ansible-galaxy role: error: argument ROLE_ACTION: invalid choice: 'roles' (choose from 'init', 'remove', 'delete', 'list', 'search', 'import', 'setup', 'login', 'info', 'install')
```